### PR TITLE
Update composer.json version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.3.*"
+        "zendframework/zendframework": ">=2.3.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
README says this module requires zf2 >2.3.3.  The current requirement is composer requirement is for 2.3.* (implicitly 2.3.0 but not 2.4).  The module seems to work fine in 2.4.0.  I don't know the usual protocol, , but I'm submitting >=2.3.3 but am open to anything that gets 2.4 into the scope.